### PR TITLE
Version bump for Hanami 0.8

### DIFF
--- a/lib/newrelic-hanami/version.rb
+++ b/lib/newrelic-hanami/version.rb
@@ -1,5 +1,5 @@
 module NewRelic
   module Hanami
-    VERSION = '0.4.1'
+    VERSION = '0.4.2'
   end
 end

--- a/newrelic-hanami.gemspec
+++ b/newrelic-hanami.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'newrelic_rpm'
-  spec.add_runtime_dependency 'hanami-controller', '> 0.4.0', '< 0.7.0'
+  spec.add_runtime_dependency 'hanami-controller', '> 0.4.0', '< 0.8.0'
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
- Expanded hanami-controller spec to allow 0.7.x which is used by Hanami 0.8
- Bumped version
