### PR TITLE
use class name for action name

### DIFF
--- a/lib/newrelic-hanami/instrument.rb
+++ b/lib/newrelic-hanami/instrument.rb
@@ -8,6 +8,7 @@ module NewRelic
     module Instrumentation
       module Hanami
         include ControllerInstrumentation
+        NAME_REGEX = /Controllers::/.freeze
 
       protected
 
@@ -22,7 +23,7 @@ module NewRelic
         def _trace_options
           {
             category: :controller,
-            name:     self.class.name.gsub('Controllers::', ''),
+            name:     self.class.name.sub(NAME_REGEX, ''),
             request:  request,
             params:   params.to_h
           }

--- a/lib/newrelic-hanami/instrument.rb
+++ b/lib/newrelic-hanami/instrument.rb
@@ -22,7 +22,7 @@ module NewRelic
         def _trace_options
           {
             category: :controller,
-            path:     "#{request.request_method} #{request.path}",
+            name:     self.class.name.gsub('Controllers::', ''),
             request:  request,
             params:   params.to_h
           }

--- a/spec/newrelic-hanami/instrument_spec.rb
+++ b/spec/newrelic-hanami/instrument_spec.rb
@@ -3,8 +3,9 @@ describe NewRelic::Agent::Instrumentation::Hanami do
     NewRelic::Agent::Instrumentation::ControllerInstrumentation
   end
 
-  let(:action) do
-    Class.new do
+  before do
+    stub_const 'Web::Controllers::Home::Index', Class.new
+    Web::Controllers::Home::Index.class_eval do
       include Hanami::Action
 
       def call(params)
@@ -16,7 +17,7 @@ describe NewRelic::Agent::Instrumentation::Hanami do
   it 'perform_action_with_newrelic_trace' do
     expect_any_instance_of(subject).to receive(
       :perform_action_with_newrelic_trace)
-    code, headers, body = action.new.call({})
+    code, headers, body = Web::Controllers::Home::Index.new.call({})
 
     expect(code).to    eq(200)
     expect(headers).to eq({})


### PR DESCRIPTION
This uses the controller class name for reporting. It will remove `Controllers::`, so that `Web::Controllers::Home::Index` is reported as `Web::Home::Index` in NR. I'm open to better ideas, this was just the most straightforward way I thought of.

I had to modify the test for it, I hope the update is acceptable.