### PR TITLE
fix transaction naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ run Hanami::Container.new
 
 ```
 
+If that doesn't work, include this in your `web/application.rb`:
+```
+module Web
+  class Application < Hanami::Application
+    configure do
+      ...
+
+      controller.prepare do
+        include ::NewRelic::Agent::Instrumentation::Hanami
+      end
+
+      ...
+    end
+  end
+end
+```
+
+
 Then add `newrelic.yml` to `config` folder.
 
 ---

--- a/lib/newrelic-hanami/instrument.rb
+++ b/lib/newrelic-hanami/instrument.rb
@@ -26,7 +26,7 @@ module NewRelic
             category:   :controller,
             class_name: trace_class_name,
             name:       trace_method_name,
-            request:    request,
+            request:    self,
             params:     params.to_h
           }
         end

--- a/lib/newrelic-hanami/instrument.rb
+++ b/lib/newrelic-hanami/instrument.rb
@@ -20,14 +20,32 @@ module NewRelic
 
       private
 
+        # providing :class_name and :name produces 'Web::User#Get' for the transaction naming
         def _trace_options
           {
-            category: :controller,
-            name:     self.class.name.sub(NAME_REGEX, ''),
-            request:  request,
-            params:   params.to_h
+            category:   :controller,
+            class_name: trace_class_name,
+            name:       trace_method_name,
+            request:    request,
+            params:     params.to_h
           }
         end
+
+        ## like 'Web::User::Get' => ['Web','User','Get']
+        def trace_controller_names
+          @trace_controller_names ||= self.class.name.sub(NAME_REGEX, '').split('::')
+        end
+
+        ## 'Get'
+        def trace_method_name
+          trace_controller_names.last
+        end
+
+        ## 'Web::User'
+        def trace_class_name
+          trace_controller_names[0...-1].join('::')
+        end
+
       end
     end
   end


### PR DESCRIPTION
The current plugin uses both the class name of the controller, plus the reduced class name, like `Web::Controllers::User::Get#Web::User::Get`

By providing both 'class_name' and 'name', this can be reduced to just `Web::User#Get` for the transaction names.

Also, the dependency detection doesn't always install the module correctly, unless you add it to the application config directly, so I noted this in the README. 